### PR TITLE
use stable bluebuild 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,4 +35,3 @@ jobs:
           registry_token: ${{ github.token }}
           pr_event_number: ${{ github.event.number }}
           maximize_build_space: false
-          use_unstable_cli: true

--- a/README.md
+++ b/README.md
@@ -5,7 +5,3 @@
 _...or "yet another aurora" :D_
 
 This is [aurora-dx:stable](https://github.com/ublue-os/bluefin/pkgs/container/aurora-dx/) with the extra packages that I like, built via [BlueBuild](https://blue-build.org/how-to/setup/).
-
-## next
-
-- Switch back to stable `bluebuild` version once 0.9 is released


### PR DESCRIPTION
The [latest release](https://github.com/blue-build/cli/releases/tag/v0.8.22) includes the base labels I need.